### PR TITLE
Fix broken links in README

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -21,7 +21,7 @@ Contributors **must** follow the following rules:
 Contributors wishing to edit a module's files should follow the following process:
 
 1. Create your GitHub account, if you do not have one already.
-2. Fork the ps_specials project to your GitHub account.
+2. Fork the ps_themecusto project to your GitHub account.
 3. Clone your fork to your local machine in the ```/modules``` directory of your PrestaShop installation.
 4. Create a branch in your local clone of the module for your changes.
 5. Change the files in your branch. Be sure to follow [the coding standards][1]!
@@ -30,3 +30,7 @@ Contributors wishing to edit a module's files should follow the following proces
 8. Wait for one of the core developers either to include your change in the codebase, or to comment on possible improvements you should make to your code.
 
 That's it: you have contributed to this open-source project! Congratulations!
+
+[1]: http://doc.prestashop.com/display/PS16/Coding+Standards
+[2]: http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message
+[3]: https://help.github.com/articles/using-pull-requests


### PR DESCRIPTION
- add link definitions numbers to fix broken links
- update module name

I used [ps_special](https://github.com/PrestaShop/ps_specials) Readme as an example. I hope this is useful 😃 