### PR TITLE
Avoid use of module->id when missing from filesystem

### DIFF
--- a/controllers/admin/AdminPsThemeCustoConfiguration.php
+++ b/controllers/admin/AdminPsThemeCustoConfiguration.php
@@ -261,6 +261,7 @@ class AdminPsThemeCustoConfigurationController extends ModuleAdminController
     */
     public function setFinalList($aList)
     {
+        $modulesOnDisk = Module::getModulesDirOnDisk();
         $aModuleFinalList = array();
 
         foreach ($aList as $sSegmentName => $aElementListByType) {
@@ -274,28 +275,20 @@ class AdminPsThemeCustoConfigurationController extends ModuleAdminController
                     }
                 } else {
                     foreach ($aElementsList as $sModuleName => $iModuleId) {
-                        $oModuleInstance = Module::getInstanceByName($sModuleName);
-                        if (Module::isInstalled($sModuleName) && $oModuleInstance !== false) {
-                            $aModuleFinalList[$sSegmentName][$sType][$sModuleName] = $this->setModuleFinalList($oModuleInstance, true);
-                            unset($oModuleInstance);
-                        } else {
-                            if ($this->module->ready === false) {
-                                try {
-                                    $oModuleInstance = Module::getInstanceByName($sModuleName);
-                                    $aModuleFinalList[$sSegmentName][$sType][$sModuleName] = $this->setModuleFinalList($oModuleInstance, false);
-                                    unset($oModuleInstance);
-                                } catch (Exception $e) {
-                                    /* For a module coming from outside. It will be downloaded and installed */
-                                    file_put_contents(_PS_MODULE_DIR_.basename($sModuleName).'.zip', Tools::addonsRequest('module', array('id_module' => $iModuleId)));
-                                    if (Tools::ZipExtract(_PS_MODULE_DIR_.basename($sModuleName).'.zip', _PS_MODULE_DIR_)) {
-                                        @unlink(_PS_MODULE_DIR_.basename($sModuleName).'.zip');
-                                        $oModuleInstance = Module::getInstanceByName($sModuleName);
-                                        $aModuleFinalList[$sSegmentName][$sType][$sModuleName] = $this->setModuleFinalList($oModuleInstance, false);
-                                        unset($oModuleInstance);
-                                    }
-                                }
+                        if (!in_array($sModuleName, $modulesOnDisk)) {
+                            if ($this->module->ready !== false) {
+                                continue;
+                            }
+                            /* For a module coming from outside. It will be downloaded and installed */
+                            file_put_contents(_PS_MODULE_DIR_.basename($sModuleName).'.zip', Tools::addonsRequest('module', array('id_module' => $iModuleId)));
+                            if (Tools::ZipExtract(_PS_MODULE_DIR_.basename($sModuleName).'.zip', _PS_MODULE_DIR_)) {
+                                @unlink(_PS_MODULE_DIR_.basename($sModuleName).'.zip');
+                            } else {
+                                continue;
                             }
                         }
+
+                        $aModuleFinalList[$sSegmentName][$sType][$sModuleName] = $this->setModuleFinalList(Module::getInstanceByName($sModuleName), Module::isInstalled($sModuleName));
                     }
                 }
             }

--- a/controllers/admin/AdminPsThemeCustoConfiguration.php
+++ b/controllers/admin/AdminPsThemeCustoConfiguration.php
@@ -274,15 +274,14 @@ class AdminPsThemeCustoConfigurationController extends ModuleAdminController
                     }
                 } else {
                     foreach ($aElementsList as $sModuleName => $iModuleId) {
-                        if (Module::isInstalled($sModuleName)) {
-                            $oModuleInstance = Module::getInstanceByName($sModuleName);
+                        $oModuleInstance = Module::getInstanceByName($sModuleName);
+                        if (Module::isInstalled($sModuleName) && $oModuleInstance !== false) {
                             $aModuleFinalList[$sSegmentName][$sType][$sModuleName] = $this->setModuleFinalList($oModuleInstance, true);
                             unset($oModuleInstance);
                         } else {
                             if ($this->module->ready === false) {
                                 try {
-                                    include_once(_PS_MODULE_DIR_.basename($sModuleName).'/'.basename($sModuleName).'.php');
-                                    $oModuleInstance = new $sModuleName();
+                                    $oModuleInstance = Module::getInstanceByName($sModuleName);
                                     $aModuleFinalList[$sSegmentName][$sType][$sModuleName] = $this->setModuleFinalList($oModuleInstance, false);
                                     unset($oModuleInstance);
                                 } catch (Exception $e) {
@@ -290,8 +289,7 @@ class AdminPsThemeCustoConfigurationController extends ModuleAdminController
                                     file_put_contents(_PS_MODULE_DIR_.basename($sModuleName).'.zip', Tools::addonsRequest('module', array('id_module' => $iModuleId)));
                                     if (Tools::ZipExtract(_PS_MODULE_DIR_.basename($sModuleName).'.zip', _PS_MODULE_DIR_)) {
                                         @unlink(_PS_MODULE_DIR_.basename($sModuleName).'.zip');
-                                        include_once(_PS_MODULE_DIR_.basename($sModuleName).'/'.basename($sModuleName).'.php');
-                                        $oModuleInstance = new $sModuleName();
+                                        $oModuleInstance = Module::getInstanceByName($sModuleName);
                                         $aModuleFinalList[$sSegmentName][$sType][$sModuleName] = $this->setModuleFinalList($oModuleInstance, false);
                                         unset($oModuleInstance);
                                     }
@@ -326,7 +324,7 @@ class AdminPsThemeCustoConfigurationController extends ModuleAdminController
         $aModule['id_module'] = $oModuleInstance->id;
         $aModule['active'] = $oModuleInstance->active;
 
-        
+
 
         if ($bIsInstalled === true) {
             $aModule['can_configure'] = (method_exists($oModuleInstance, 'getContent'))? true : false;

--- a/controllers/admin/AdminPsThemeCustoConfiguration.php
+++ b/controllers/admin/AdminPsThemeCustoConfiguration.php
@@ -280,8 +280,8 @@ class AdminPsThemeCustoConfigurationController extends ModuleAdminController
                                 continue;
                             }
                             /* For a module coming from outside. It will be downloaded and installed */
-                            file_put_contents(_PS_MODULE_DIR_.basename($sModuleName).'.zip', Tools::addonsRequest('module', array('id_module' => $iModuleId)));
-                            if (Tools::ZipExtract(_PS_MODULE_DIR_.basename($sModuleName).'.zip', _PS_MODULE_DIR_)) {
+                            $length = file_put_contents(_PS_MODULE_DIR_.basename($sModuleName).'.zip', Tools::addonsRequest('module', array('id_module' => $iModuleId)));
+                            if (!empty($length) && Tools::ZipExtract(_PS_MODULE_DIR_.basename($sModuleName).'.zip', _PS_MODULE_DIR_)) {
                                 @unlink(_PS_MODULE_DIR_.basename($sModuleName).'.zip');
                             } else {
                                 continue;


### PR DESCRIPTION
When a module is installed but deleted from the filesystem, the `Module` still thinks it is installed. We must try to load it too see that it is actually missing.