### PR TITLE
Correcting button on responsive by adding a new css rule

### DIFF
--- a/views/css/general.css
+++ b/views/css/general.css
@@ -96,6 +96,7 @@
     text-transform: initial;
     background-color: #25b9d7 !important;
     border-color: #25b9d7 !important;
+    white-space: pre-wrap;
 }
 #psthemecusto .btn.btn-primary:hover {
     background-color: #3ed2f0 !important;


### PR DESCRIPTION
# Issue https://github.com/PrestaShop/ps_themecusto/issues/7
* Adding white-space: pre-wrap; rule