### PR TITLE
Check if file exists before requiring it

### DIFF
--- a/controllers/admin/AdminPsThemeCustoConfiguration.php
+++ b/controllers/admin/AdminPsThemeCustoConfiguration.php
@@ -23,7 +23,9 @@
 * @license http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
 * International Registered Trademark & Property of PrestaShop SA
 **/
-require_once _PS_MODULE_DIR_ . 'ps_themecusto/vendor/autoload.php';
+if (file_exists(_PS_MODULE_DIR_ . 'ps_themecusto/vendor/autoload.php')) {
+    require_once _PS_MODULE_DIR_ . 'ps_themecusto/vendor/autoload.php';
+}
 
 class AdminPsThemeCustoConfigurationController extends ModuleAdminController
 {


### PR DESCRIPTION
Since this module is now a native one, the `autoload.php` file doesn't exist by default so we should test it before requiring it.

This fixes the issue [#17374](https://github.com/PrestaShop/PrestaShop/issues/17374)