### PR TITLE
Remove enable/disable mobile when module is disabled

### DIFF
--- a/views/templates/admin/controllers/configuration/elem/module_actions.tpl
+++ b/views/templates/admin/controllers/configuration/elem/module_actions.tpl
@@ -70,11 +70,11 @@
                                 <button type="button" class="dropdown-item module_action_menu_{$action}">
                                     {l s='Enable' mod='ps_themecusto'}
                                 </button>
-                            {elseif ($module.enable_mobile eq 7 || $module.enable_mobile eq 1 || $module.enable_mobile eq 0) && $action eq 'disable_mobile'}
+                            {elseif ($module.enable_mobile eq 7 || $module.enable_mobile eq 1) && $action eq 'disable_mobile'}
                                 <button type="button" class="dropdown-item module_action_menu_{$action}">
                                     {l s='Disable mobile' mod='ps_themecusto'}
                                 </button>
-                            {elseif ($module.enable_mobile eq 3 || $module.enable_mobile eq 0) && $action eq 'enable_mobile'}
+                            {elseif $module.enable_mobile eq 3 && $action eq 'enable_mobile'}
                                 <button type="button" class="dropdown-item module_action_menu_{$action}">
                                     {l s='Enable mobile' mod='ps_themecusto'}
                                 </button>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Remove enable/disable mobile when module is disabled
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/Prestashop#24470
| How to test?  | Cf. PrestaShop/Prestashop#24470

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
