### PR TITLE
Trivial display issue &amps; + space

### DIFF
--- a/controllers/admin/AdminPsThemeCustoConfiguration.php
+++ b/controllers/admin/AdminPsThemeCustoConfiguration.php
@@ -59,7 +59,7 @@ class AdminPsThemeCustoConfigurationController extends ModuleAdminController
             'home_products' => $this->l('Home Products'),
             'block_text' => $this->l('Text block'),
             'banner' => $this->l('Banner'),
-            'social_newsletter' => $this->l('Social &  Newsletter'),
+            'social_newsletter' => $this->l('Social and Newsletter'),
             'footer' => $this->l('Footer'),
             'content' => $this->l('content'),
             'categories' => $this->l('Categories'),

--- a/controllers/admin/AdminPsThemeCustoConfiguration.php
+++ b/controllers/admin/AdminPsThemeCustoConfiguration.php
@@ -59,7 +59,7 @@ class AdminPsThemeCustoConfigurationController extends ModuleAdminController
             'home_products' => $this->l('Home Products'),
             'block_text' => $this->l('Text block'),
             'banner' => $this->l('Banner'),
-            'social_newsletter' => $this->l('Social and Newsletter'),
+            'social_newsletter' => $this->l('Social & Newsletter'),
             'footer' => $this->l('Footer'),
             'content' => $this->l('content'),
             'categories' => $this->l('Categories'),

--- a/views/templates/admin/controllers/configuration/dropdownList.tpl
+++ b/views/templates/admin/controllers/configuration/dropdownList.tpl
@@ -10,7 +10,7 @@
                     <div class="row configuration-rectangle">
                         <div class="col-lg-12 col-md-12 col-sm-12 col-xs-12 js-module-name js-title-{$categoryname}" data-module_name="{$categoryname}">
                             <span class="col-lg-11 col-sm-11 col-xs-11 col-md-11">
-                                {$listCategories[$categoryname]}
+                                {$listCategories[$categoryname]|unescape:"entity"}
                             </span>
                             <span class="col-lg-1 col-sm-1 col-xs-1 col-md-1 configuration-rectangle-caret">
                                 <i class="material-icons down">keyboard_arrow_down</i>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | In Design > Theme & Logo > Pages configuration. Only "&" should be displayed.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/Prestashop#29002.
| How to test?  | See issue

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
