### PR TITLE
Fix the name of the anchor in the link to installed modules page

### DIFF
--- a/views/templates/admin/controllers/configuration/dropdownList.tpl
+++ b/views/templates/admin/controllers/configuration/dropdownList.tpl
@@ -153,7 +153,7 @@
 
                 <div class="row">
                     <div class="col-lg-4 col-lg-offset-8">
-                        <a class="btn btn-primary btn-lg btn-block" href="{$installedModulePage}#theme_modules">
+                        <a class="btn btn-primary btn-lg btn-block" href="{$installedModulePage}#theme_modules_modules">
                             {l s='See all theme\'s modules' mod='ps_themecusto'}
                         </a>
                     </div>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | The link "See all theme's modules" on Admin UI, in the section "Design > Theme & Logo > Pages Configuration"-page points to an anchor that doesn't exist in the Installed Modules Page. This simple PR corrects the anchor id in the link so the page is scrolled to the correct position.<br>This fix is simplest possible to enhance the user experience. I thought about instead building support for pre-selecting the Theme Modules-category which would filter out other categories and is superior in terms of usability, but since that functionality doesn't exist, I saw that option as more of an enhancement than a bug fix.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/Prestashop#35204.
| How to test?  | In Admin UI, got to Design > Theme & Logo > Pages Configuration and click on the See all theme's modules-button. You should arrive at the Installed modules page and be automatically scrolled to the Theme Modules section.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
