### PR TITLE
Remove hexadecimal value in module field that is never used anyway

### DIFF
--- a/ps_themecusto.php
+++ b/ps_themecusto.php
@@ -29,7 +29,6 @@ if (!defined('_PS_VERSION_')) {
 
 class ps_themecusto extends Module
 {
-    public $author_address;
     public $bootstrap;
     public $controller_name;
     public $front_controller = [];
@@ -48,7 +47,6 @@ class ps_themecusto extends Module
         $this->version = '1.2.4';
         $this->author = 'PrestaShop';
         $this->module_key = 'af0983815ad8c8a193b5dc9168e8372e';
-        $this->author_address = '0x64aa3c1e4034d07015f639b0e171b0d7b27d01aa';
         $this->bootstrap = true;
 
         parent::__construct();


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Remove hexadecimal value in module field that is never used anyway
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes validation of module
| How to test?  | The module must behave as it used to

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
