### PR TITLE
Accept child-theme zips without explicit directory entries

### DIFF
--- a/controllers/admin/AdminPsThemeCustoAdvanced.php
+++ b/controllers/admin/AdminPsThemeCustoAdvanced.php
@@ -419,9 +419,14 @@ class AdminPsThemeCustoAdvancedController extends ModuleAdminController
 
         for ($i = 0; $i < $oZip->numFiles; ++$i) {
             $aZipElement = array_filter(explode('/', $oZip->getNameIndex($i)));
-            if (count($aZipElement) == 1) {
-                $aRootFilesAndFolders[] = $aZipElement[0];
+            if (empty($aZipElement)) {
+                continue;
             }
+            // Collect the first path segment of every entry. The "config" folder may be present
+            // only implicitly (e.g. "config/theme.yml") when the archive carries no explicit
+            // directory entries, so relying on a standalone "config/" entry rejected otherwise
+            // valid zips with "The file is not valid.".
+            $aRootFilesAndFolders[] = reset($aZipElement);
         }
 
         $oZip->close();


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Uploading a customised child theme via **Design > Theme & Logo > Advanced customization** failed with **"The file is not valid."** whenever the uploaded `.zip` did not contain explicit directory entries. `AdminPsThemeCustoAdvancedController::processCheckZipFormat()` decided the archive was valid only if `config` appeared as a *root-level* entry, but it built that root list by keeping entries whose path had a single segment after `array_filter(explode('/', name))`. A bare directory entry (`config/`) yields one segment and passes; a file entry (`config/theme.yml`) yields two and is skipped. Many zip tools (and re-zipping the extracted child theme) omit directory entries entirely, so a structurally correct theme was rejected. The fix inspects the **first path segment of every entry**, so the `config` folder is detected whether it is described explicitly (a `config/` entry) or only implicitly (through `config/...` files).
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/PrestaShop#40615.
| How to test?  | Create a valid child theme zip whose archive contains **no explicit directory entries** (e.g. build it programmatically, or `cd child && zip -X -r ../child.zip . -x '*/'`), with `config/theme.yml` at the root. Before: uploading it under Advanced customization fails with "The file is not valid." After: it is accepted. A zip that *does* contain a `config/` directory entry keeps working, and a zip wrapped in a single root folder is still normalised by `checkZipFile()` before this check.

#### Root cause, reproduced

`processCheckZipFormat()` reduced to its decision logic, run on two archives with identical files:

```
implicit dirs  (entries: config/theme.yml, preview.png, assets/css/theme.css)        => current: INVALID   fixed: VALID
explicit dirs  (entries: config/, config/theme.yml, preview.png, assets/, ...)        => current: VALID     fixed: VALID
```

The only difference between the two is whether the archive carries directory entries — the file layout is the same — yet only the explicit one was accepted. After the fix both are accepted, because the check no longer depends on the presence of directory entries.

> Note: the module has no PHPUnit harness, so the behaviour above was verified by exercising the method's logic directly against crafted archives rather than with an added unit test.
